### PR TITLE
fix(store): update machines table primary key

### DIFF
--- a/store/shared/migrate/mysql/ddl_gen.go
+++ b/store/shared/migrate/mysql/ddl_gen.go
@@ -32,6 +32,18 @@ var migrations = []struct {
 		name: "create-table-machines",
 		stmt: createTableMachines,
 	},
+	{
+		name: "create-index-machines-owner",
+		stmt: createIndexMachinesOwner,
+	},
+	{
+		name: "create-index-machines-status",
+		stmt: createIndexMachinesStatus,
+	},
+	{
+		name: "create-index-machines-last-seen",
+		stmt: createIndexMachinesLastSeen,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -245,7 +257,7 @@ CREATE INDEX idx_memberships_user_id ON memberships(membership_user_id);
 
 var createTableMachines = `
 CREATE TABLE IF NOT EXISTS machines (
-  machine_name            VARCHAR(255) PRIMARY KEY,
+  machine_name            VARCHAR(255),
   machine_owner           VARCHAR(255),
   machine_arch            VARCHAR(50),
   machine_cpu             BIGINT,
@@ -260,10 +272,20 @@ CREATE TABLE IF NOT EXISTS machines (
   machine_last_seen       BIGINT,
   machine_updated         BIGINT,
   machine_token           TEXT,
+
+  PRIMARY KEY(machine_name, machine_owner),
   UNIQUE(machine_token)
 );
+`
 
+var createIndexMachinesOwner = `
 CREATE INDEX ix_machine_owner ON machines (machine_owner);
+`
+
+var createIndexMachinesStatus = `
 CREATE INDEX ix_machine_status ON machines (machine_status);
+`
+
+var createIndexMachinesLastSeen = `
 CREATE INDEX ix_machine_last_seen ON machines (machine_last_seen);
 `

--- a/store/shared/migrate/mysql/files/0006_create_table_machines.sql
+++ b/store/shared/migrate/mysql/files/0006_create_table_machines.sql
@@ -1,7 +1,7 @@
 -- name: create-table-machines
 
 CREATE TABLE IF NOT EXISTS machines (
-  machine_name            VARCHAR(255) PRIMARY KEY,
+  machine_name            VARCHAR(255),
   machine_owner           VARCHAR(255),
   machine_arch            VARCHAR(50),
   machine_cpu             BIGINT,
@@ -16,9 +16,19 @@ CREATE TABLE IF NOT EXISTS machines (
   machine_last_seen       BIGINT,
   machine_updated         BIGINT,
   machine_token           TEXT,
+
+  PRIMARY KEY(machine_name, machine_owner),
   UNIQUE(machine_token)
 );
 
+-- name: create-index-machines-owner
+
 CREATE INDEX ix_machine_owner ON machines (machine_owner);
+
+-- name: create-index-machines-status
+
 CREATE INDEX ix_machine_status ON machines (machine_status);
+
+-- name: create-index-machines-last-seen
+
 CREATE INDEX ix_machine_last_seen ON machines (machine_last_seen);

--- a/store/shared/migrate/postgres/ddl_gen.go
+++ b/store/shared/migrate/postgres/ddl_gen.go
@@ -32,6 +32,18 @@ var migrations = []struct {
 		name: "create-table-machines",
 		stmt: createTableMachines,
 	},
+	{
+		name: "create-index-machines-owner",
+		stmt: createIndexMachinesOwner,
+	},
+	{
+		name: "create-index-machines-status",
+		stmt: createIndexMachinesStatus,
+	},
+	{
+		name: "create-index-machines-last-seen",
+		stmt: createIndexMachinesLastSeen,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -245,7 +257,7 @@ CREATE INDEX IF NOT EXISTS idx_memberships_user_id ON memberships(membership_use
 
 var createTableMachines = `
 CREATE TABLE IF NOT EXISTS machines (
-  machine_name            VARCHAR(255) PRIMARY KEY,
+  machine_name            VARCHAR(255),
   machine_owner           VARCHAR(255),
   machine_arch            VARCHAR(50),
   machine_cpu             BIGINT,
@@ -260,10 +272,20 @@ CREATE TABLE IF NOT EXISTS machines (
   machine_last_seen       BIGINT,
   machine_updated         BIGINT,
   machine_token           TEXT,
+
+  PRIMARY KEY(machine_name, machine_owner),
   UNIQUE(machine_token)
 );
+`
 
+var createIndexMachinesOwner = `
 CREATE INDEX IF NOT EXISTS ix_machine_owner ON machines (machine_owner);
+`
+
+var createIndexMachinesStatus = `
 CREATE INDEX IF NOT EXISTS ix_machine_status ON machines (machine_status);
+`
+
+var createIndexMachinesLastSeen = `
 CREATE INDEX IF NOT EXISTS ix_machine_last_seen ON machines (machine_last_seen);
 `

--- a/store/shared/migrate/postgres/files/0006_create_table_machines.sql
+++ b/store/shared/migrate/postgres/files/0006_create_table_machines.sql
@@ -1,7 +1,7 @@
 -- name: create-table-machines
 
 CREATE TABLE IF NOT EXISTS machines (
-  machine_name            VARCHAR(255) PRIMARY KEY,
+  machine_name            VARCHAR(255),
   machine_owner           VARCHAR(255),
   machine_arch            VARCHAR(50),
   machine_cpu             BIGINT,
@@ -16,9 +16,19 @@ CREATE TABLE IF NOT EXISTS machines (
   machine_last_seen       BIGINT,
   machine_updated         BIGINT,
   machine_token           TEXT,
+
+  PRIMARY KEY(machine_name, machine_owner),
   UNIQUE(machine_token)
 );
 
+-- name: create-index-machines-owner
+
 CREATE INDEX IF NOT EXISTS ix_machine_owner ON machines (machine_owner);
+
+-- name: create-index-machines-status
+
 CREATE INDEX IF NOT EXISTS ix_machine_status ON machines (machine_status);
+
+-- name: create-index-machines-last-seen
+
 CREATE INDEX IF NOT EXISTS ix_machine_last_seen ON machines (machine_last_seen);

--- a/store/shared/migrate/sqlite/ddl_gen.go
+++ b/store/shared/migrate/sqlite/ddl_gen.go
@@ -32,6 +32,18 @@ var migrations = []struct {
 		name: "create-table-machines",
 		stmt: createTableMachines,
 	},
+	{
+		name: "create-index-machines-owner",
+		stmt: createIndexMachinesOwner,
+	},
+	{
+		name: "create-index-machines-status",
+		stmt: createIndexMachinesStatus,
+	},
+	{
+		name: "create-index-machines-last-seen",
+		stmt: createIndexMachinesLastSeen,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -245,7 +257,7 @@ CREATE INDEX IF NOT EXISTS idx_memberships_user_id ON memberships(membership_use
 
 var createTableMachines = `
 CREATE TABLE IF NOT EXISTS machines (
-  machine_name           TEXT PRIMARY KEY COLLATE NOCASE,
+  machine_name           TEXT,
   machine_owner          TEXT,
   machine_arch           TEXT,
   machine_cpu            INTEGER,
@@ -260,10 +272,20 @@ CREATE TABLE IF NOT EXISTS machines (
   machine_last_seen      INTEGER,
   machine_updated        INTEGER,
   machine_token          TEXT,
+
+  PRIMARY KEY(machine_name, machine_owner)
   UNIQUE(machine_token)
 );
+`
 
+var createIndexMachinesOwner = `
 CREATE INDEX IF NOT EXISTS ix_machine_owner ON machines (machine_owner);
+`
+
+var createIndexMachinesStatus = `
 CREATE INDEX IF NOT EXISTS ix_machine_status ON machines (machine_status);
+`
+
+var createIndexMachinesLastSeen = `
 CREATE INDEX IF NOT EXISTS ix_machine_last_seen ON machines (machine_last_seen);
 `

--- a/store/shared/migrate/sqlite/files/0006_create_table_machines.sql
+++ b/store/shared/migrate/sqlite/files/0006_create_table_machines.sql
@@ -1,7 +1,7 @@
 -- name: create-table-machines
 
 CREATE TABLE IF NOT EXISTS machines (
-  machine_name           TEXT PRIMARY KEY COLLATE NOCASE,
+  machine_name           TEXT,
   machine_owner          TEXT,
   machine_arch           TEXT,
   machine_cpu            INTEGER,
@@ -16,9 +16,19 @@ CREATE TABLE IF NOT EXISTS machines (
   machine_last_seen      INTEGER,
   machine_updated        INTEGER,
   machine_token          TEXT,
+
+  PRIMARY KEY(machine_name, machine_owner)
   UNIQUE(machine_token)
 );
 
+-- name: create-index-machines-owner
+
 CREATE INDEX IF NOT EXISTS ix_machine_owner ON machines (machine_owner);
+
+-- name: create-index-machines-status
+
 CREATE INDEX IF NOT EXISTS ix_machine_status ON machines (machine_status);
+
+-- name: create-index-machines-last-seen
+
 CREATE INDEX IF NOT EXISTS ix_machine_last_seen ON machines (machine_last_seen);


### PR DESCRIPTION
Update machines table's primary key to avoid conflict when creating a machine with the same name cross owners